### PR TITLE
Fix issues raised by valgrind

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -34,4 +34,6 @@ int main ()
   };
   char *template = render_template("./templates/index.html", 2, keys, values);
   printf("%s\n", template);
+  if(template) free(template);
+  return 0;
 }

--- a/src/template_functions.c
+++ b/src/template_functions.c
@@ -77,7 +77,9 @@ char *set_template_var(char* template, const char* key, const char* value)
   strcat(fullkey, "{{data.");
   strcat(fullkey, key);
   strcat(fullkey, "}}");
-  return str_replace(template, fullkey, value);
+  char *ret = str_replace(template, fullkey, value);
+  free(fullkey);
+  return ret;
 }
 
 char *render_template(const char* filename, int len, const char *keys[], const char *values[])


### PR DESCRIPTION
Should fix issue #5 .

## Before:

==3137== 
==3137== HEAP SUMMARY:
==3137==     in use at exit: 356 bytes in 3 blocks
==3137==   total heap usage: 8 allocs, 5 frees, 6,546 bytes allocated
==3137== 
==3137== 29 bytes in 2 blocks are definitely lost in loss record 1 of 2
==3137==    at 0x4C2EB6B: malloc (vg_replace_malloc.c:299)
==3137==    by 0x400B34: set_template_var (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137==    by 0x400C5E: render_template (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137==    by 0x400E9B: main (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137== 
==3137== 327 bytes in 1 blocks are definitely lost in loss record 2 of 2
==3137==    at 0x4C2EB6B: malloc (vg_replace_malloc.c:299)
==3137==    by 0x400D8B: str_replace (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137==    by 0x400BE1: set_template_var (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137==    by 0x400C5E: render_template (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137==    by 0x400E9B: main (in /home/ottani/proj/simplectemplate/simplectemplate)
==3137== 
==3137== LEAK SUMMARY:
==3137==    definitely lost: 356 bytes in 3 blocks
==3137==    indirectly lost: 0 bytes in 0 blocks
==3137==      possibly lost: 0 bytes in 0 blocks
==3137==    still reachable: 0 bytes in 0 blocks
==3137==         suppressed: 0 bytes in 0 blocks
==3137== 
==3137== For counts of detected and suppressed errors, rerun with: -v
==3137== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)


## After:
==3991== 
==3991== HEAP SUMMARY:
==3991==     in use at exit: 0 bytes in 0 blocks
==3991==   total heap usage: 8 allocs, 8 frees, 6,546 bytes allocated
==3991== 
==3991== All heap blocks were freed -- no leaks are possible
==3991== 
==3991== For counts of detected and suppressed errors, rerun with: -v
==3991== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
