### PR TITLE
Updated Makefile to use CC system var if it is defined. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TARGET = simplectemplate
 LIBS = -lm
-CC = gcc
+CC ?= gcc # Use gcc if CC is undefined
 CFLAGS = -Wall
 
 .PHONY: default all clean


### PR DESCRIPTION
Otherwise default to gcc, so travis can build with the 3 different compilers, also so we can test our travis trigger on develop. Should finalized and fix #12 