### PR TITLE
Support nested placeholders and support for condition prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ char *template = render_template("<!DOCTYPE html> \n\
     <p>In the short term future, this will be the same sytax for looped data</p> \n\
     {{/is_not_error}} \n\
   </body> \n\
-</html>", 2, data);
+</html>", 5, data);
 
 printf("%s\n", template);
 ```
@@ -118,7 +118,7 @@ char *template = my_render_template("<!DOCTYPE html> \n\
     <p>In the short term future, this will be the same sytax for looped data</p> \n\
     $[[-is_not_error]] \n\
   </body> \n\
-</html>", 2, data, (struct RenderOptions){.placeholder_open="$[[", .placeholder_close="]]", .data_cond_open_prefix="?", .data_cond_close_prefix="-", .data_cond_separator=" "});
+</html>", 5, data, (struct RenderOptions){.placeholder_open="$[[", .placeholder_close="]]", .data_cond_open_prefix="?", .data_cond_close_prefix="-", .data_cond_separator=" "});
 
 printf("%s\n", template);
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Master: [![Build Status](https://travis-ci.org/dafky2000/simplectemplate.svg?bra
 
 Develop: [![Build Status](https://travis-ci.org/dafky2000/simplectemplate.svg?branch=develop)](https://travis-ci.org/dafky2000/simplectemplate) [![Coverage Status](https://coveralls.io/repos/github/dafky2000/simplectemplate/badge.svg?branch=develop)](https://coveralls.io/github/dafky2000/simplectemplate)
 
-Simple C Template library to expand placeholders in a template string, simple alternative to mustache.github.io that doesn't require JSON as data input. The main focus of this project is accessibility, making it easy and fast to hack into any project.
+Simple C Template library to expand placeholders in a template string, simple alternative to mustache.github.io that doesn't require JSON as data input. The main focus of this project is accessibility, making it easy and fast to hack into any project. Aiming to support native mustache format.
 
 ## Building and running examples / tests
 ```sh
@@ -29,8 +29,12 @@ Say you want to generate an HTML file from the template below in C:
     <title>{{title}}</title>
   </head>
   <body>
-    <h1>{{title}}</h1>
+    <h1 class="{{is_error error_class}}">{{title}}</h1>
     {{body}}
+    {{#is_not_error}}
+    <p>In addition to the is_error above with space separating the data, simplectemplate also supports opening and closing braces like this! One step closer to supporting mustache formatted templates!</p>
+    <p>In the short term future, this will be the same sytax for looped data</p>
+    {{/is_not_error}}
   </body>
 </html>
 ```
@@ -43,6 +47,9 @@ Example code:
 const char *data[] = {
 	"title", "My super cool website",
 	"body", "Put whatever you want in the body! Heck, even another rendered template ;)"
+  "is_error", "true or anything other than NULL or empty string",
+  "is_not_error", NULL, // "Evaluates" to false
+  "is_not_error", "", // Also "evaluates" to false
 };
 
 // Render the template and replace the template variables
@@ -54,18 +61,45 @@ char *template = render_template("<!DOCTYPE html> \n\
     <title>{{title}}</title> \n\
   </head> \n\
   <body> \n\
-    <h1>{{title}}</h1> \n\
+    <h1 class="{{is_error error_class}}">{{title}}</h1> \n\
     {{body}} \n\
+    {{#is_not_error}} \n\
+    <p>In addition to the is_error above with space separating the data, simplectemplate also supports opening and closing braces like this! One step closer to supporting mustache formatted templates!</p> \n\
+    <p>In the short term future, this will be the same sytax for looped data</p> \n\
+    {{/is_not_error}} \n\
   </body> \n\
 </html>", 2, data);
 
 printf("%s\n", template);
 ```
-__OR__
+
+Renders to:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My super cool website</title>
+  </head>
+  <body>
+    <h1 class="error_class">My super cool website</h1>
+    Put whatever you want in the body! Heck, even another rendered template ;)
+
+  </body>
+</html>
+```
+
+# RenderOptions - Custom opening/closing/condition prefix, condition separator, and end-block prefixes...
+
 ```c
 const char *data[] = {
 	"title", "My super cool website",
 	"body", "Put whatever you want in the body! Heck, even another rendered template ;)"
+  "is_error", "true or anything other than NULL or empty string",
+  "is_not_error", NULL, // "Evaluates" to false
+  "is_not_error", "", // Also "evaluates" to false
 };
 
 // Render the template and replace the template variables
@@ -74,17 +108,25 @@ char *template = my_render_template("<!DOCTYPE html> \n\
   <head> \n\
     <meta charset="UTF-8"> \n\
     <meta name="viewport" content="width=device-width, initial-scale=1" /> \n\
-    <title>${{data.title}}</title> \n\
+    <title>$[[data.title]]</title> \n\
   </head> \n\
   <body> \n\
-    <h1>${{data.title}}</h1> \n\
-    ${{data.body}} \n\
+    <h1 class="$[[is_error error_class]]">$[[title]]</h1> \n\
+    $[[body]] \n\
+    $[[?is_not_error]] \n\
+    <p>In addition to the is_error above with space separating the data, simplectemplate also supports opening and closing braces like this! One step closer to supporting mustache formatted templates!</p> \n\
+    <p>In the short term future, this will be the same sytax for looped data</p> \n\
+    $[[-is_not_error]] \n\
   </body> \n\
-</html>", 2, data, (struct RenderOptions){.placeholder_open="${{data.", .placeholder_close="}}"});
+</html>", 2, data, (struct RenderOptions){.placeholder_open="$[[", .placeholder_close="]]", .data_cond_open_prefix="?", .data_cond_close_prefix="-", .data_cond_separator=" "});
 
 printf("%s\n", template);
 ```
-__OR__
+
+# Helper functions
+
+## Render from file
+
 ```c
 const char *data[] = {
 	"title", "My super cool website",

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Example code:
 
 ```c
 const char *data[] = {
-	"title", "My super cool website",
-	"body", "Put whatever you want in the body! Heck, even another rendered template ;)"
+  "title", "My super cool website",
+  "body", "Put whatever you want in the body! Heck, even another rendered template ;)"
   "is_error", "true or anything other than NULL or empty string",
   "is_not_error", NULL, // "Evaluates" to false
   "is_not_error", "", // Also "evaluates" to false
@@ -95,8 +95,8 @@ Renders to:
 
 ```c
 const char *data[] = {
-	"title", "My super cool website",
-	"body", "Put whatever you want in the body! Heck, even another rendered template ;)"
+  "title", "My super cool website",
+  "body", "Put whatever you want in the body! Heck, even another rendered template ;)"
   "is_error", "true or anything other than NULL or empty string",
   "is_not_error", NULL, // "Evaluates" to false
   "is_not_error", "", // Also "evaluates" to false
@@ -129,8 +129,8 @@ printf("%s\n", template);
 
 ```c
 const char *data[] = {
-	"title", "My super cool website",
-	"body", "Put whatever you want in the body! Heck, even another rendered template ;)"
+  "title", "My super cool website",
+  "body", "Put whatever you want in the body! Heck, even another rendered template ;)"
 };
 
 // Render the template and replace the template variables
@@ -143,14 +143,14 @@ Outputs:
 ```html
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>My super cool website</title>
-	</head>
-	<body>
-		<h1>My super cool website</h1>
-		Put whatever you want in the body! Heck, even another rendered template ;)
-	</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>My super cool website</title>
+  </head>
+  <body>
+    <h1>My super cool website</h1>
+    Put whatever you want in the body! Heck, even another rendered template ;)
+  </body>
 </html>
 ```

--- a/spec/template_functions_render_template.c
+++ b/spec/template_functions_render_template.c
@@ -102,7 +102,7 @@ void spec_render_template6(void)
 		"inner", " ---- ",
 		"insideopen", " ",
 	};
-	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#insideopen}} bob loblaw {{/insideopen}}{{/open}}what happens!";
+	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#insideopen}} bob loblaw {{/insideopen}}{{/open}}what {{#notpresent}} dsadas {{/notpresent}}happens!";
 
 	/* act */
 	char* rendered = render_template(template, 4, data);

--- a/spec/template_functions_render_template.c
+++ b/spec/template_functions_render_template.c
@@ -79,7 +79,7 @@ void spec_render_template5(void)
 	const char *data[] = {
 		"ph1", "awesome",
 		"ph2", " is running",
-		"varwcondition", "",
+		"varwcondition", " ",
 		"separator", "",
 	};
 	const char* template = "My {{ph1}} test{{ph2}}{{emptyph}} {{test123 testing 1 2 ummm 12}}{{separator bob loblaw}}{{#varwcondition}}Some datas{{/varwcondition}} abc123 test test test";
@@ -88,7 +88,48 @@ void spec_render_template5(void)
 	char* rendered = render_template(template, 4, data);
 
 	/* assert */
-	sp_assert_equal_s(rendered, "My awesome test is running bob loblawSome datas abc123 test test test");
+	sp_assert_equal_s(rendered, "My awesome test is running Some datas abc123 test test test");
 
 	free(rendered);
 }
+
+void spec_render_template6(void)
+{
+	/* arrange */
+	const char *data[] = {
+		"noclosingbrace", "",
+		"open", "true",
+		"inner", " ---- ",
+		"insideopen", " ",
+	};
+	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#insideopen}} bob loblaw {{/insideopen}}{{/open}}what happens!";
+
+	/* act */
+	char* rendered = render_template(template, 4, data);
+
+	/* assert */
+	sp_assert_equal_s(rendered, "Just a test for , lets see blah blah blah  ----  blah blah blah  bob loblaw what happens!");
+
+	free(rendered);
+}
+
+void spec_render_template7(void)
+{
+	/* arrange */
+	const char *data[] = {
+		"noclosingbrace", "",
+		"open", "true",
+		"inner", " ---- ",
+		"insideopen", NULL,
+	};
+	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#insideopen}} bob loblaw {{/insideopen}}{{/open}}what happens!";
+
+	/* act */
+	char* rendered = render_template(template, 4, data);
+
+	/* assert */
+	sp_assert_equal_s(rendered, "Just a test for , lets see blah blah blah  ----  blah blah blah what happens!");
+
+	free(rendered);
+}
+

--- a/spec/template_functions_render_template.c
+++ b/spec/template_functions_render_template.c
@@ -100,9 +100,9 @@ void spec_render_template6(void)
 		"noclosingbrace", "",
 		"open", "true",
 		"inner", " ---- ",
-		"insideopen", " ",
+		"inneropen", " ",
 	};
-	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#insideopen}} bob loblaw {{/insideopen}}{{/open}}what {{#notpresent}} dsadas {{/notpresent}}happens!";
+	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#inneropen}} bob loblaw {{/inneropen}}{{/open}}what {{#notpresent}} dsadas {{/notpresent}}happens!";
 
 	/* act */
 	char* rendered = render_template(template, 4, data);
@@ -120,9 +120,9 @@ void spec_render_template7(void)
 		"noclosingbrace", "",
 		"open", "true",
 		"inner", " ---- ",
-		"insideopen", NULL,
+		"inneropen", NULL,
 	};
-	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#insideopen}} bob loblaw {{/insideopen}}{{/open}}what happens!";
+	const char* template = "Just a test for {{#noclosingbrace}}, lets see {{#open}}blah blah blah {{inner}} blah blah blah {{#inneropen}} bob loblaw {{/inneropen}}{{/open}}what happens!";
 
 	/* act */
 	char* rendered = render_template(template, 4, data);

--- a/spec/template_functions_render_template.c
+++ b/spec/template_functions_render_template.c
@@ -72,3 +72,21 @@ void spec_render_template4(void)
 
 	free(rendered);
 }
+
+void spec_render_template5(void)
+{
+	/* arrange */
+	const char *data[] = {
+		"ph1", "awesome",
+		"ph2", " is running",
+	};
+	const char* template = "My {{ph1}} test{{ph2}}{{#emptyph}} {{test123 testing 1 2 ummm 12}}{{#startandseparator bob loblaw}}";
+
+	/* act */
+	char* rendered = render_template(template, 2, data);
+
+	/* assert */
+	sp_assert_equal_s(rendered, "My awesome test is running ");
+
+	free(rendered);
+}

--- a/spec/template_functions_render_template.c
+++ b/spec/template_functions_render_template.c
@@ -79,14 +79,16 @@ void spec_render_template5(void)
 	const char *data[] = {
 		"ph1", "awesome",
 		"ph2", " is running",
+		"varwcondition", "",
+		"separator", "",
 	};
-	const char* template = "My {{ph1}} test{{ph2}}{{#emptyph}} {{test123 testing 1 2 ummm 12}}{{#startandseparator bob loblaw}}";
+	const char* template = "My {{ph1}} test{{ph2}}{{emptyph}} {{test123 testing 1 2 ummm 12}}{{separator bob loblaw}}{{#varwcondition}}Some datas{{/varwcondition}} abc123 test test test";
 
 	/* act */
-	char* rendered = render_template(template, 2, data);
+	char* rendered = render_template(template, 4, data);
 
 	/* assert */
-	sp_assert_equal_s(rendered, "My awesome test is running ");
+	sp_assert_equal_s(rendered, "My awesome test is running bob loblawSome datas abc123 test test test");
 
 	free(rendered);
 }

--- a/src/template_functions.c
+++ b/src/template_functions.c
@@ -211,6 +211,11 @@ char* my_render_template(const char* template_data, unsigned long len, const cha
 	if(data_cond_open_prefix == NULL) data_cond_open_prefix = "#";
 	if(data_cond_close_prefix == NULL) data_cond_close_prefix = "/";
 
+	char close_and_data_cond_separator[strlen(close) + strlen(data_cond_separator) + 1];
+	memset(close_and_data_cond_separator, 0, strlen(close) + strlen(data_cond_separator)+ 1);
+	strncpy(close_and_data_cond_separator, close, strlen(close));
+	strncat(close_and_data_cond_separator, data_cond_separator, strlen(data_cond_separator));
+
 	// Create a copy of the template to work with
 	unsigned long template_length = strlen(template_data) + 1;
 	char* output = malloc(template_length);
@@ -264,7 +269,6 @@ char* my_render_template(const char* template_data, unsigned long len, const cha
 			strcat(closing_text, close);
 
 			char* closing_instance = strstr(matched_start, closing_text);
-			// TODO: Add support for placeholder with no end
 			if(closing_instance != NULL) {
 				// 2) Get the data the placeholders
 				char* data_inside_start = matched_start + strlen(matched_copy) + strlen(open);
@@ -301,7 +305,6 @@ char* my_render_template(const char* template_data, unsigned long len, const cha
 		strcat(toreplace, close);
 		/* printf("toreplace: '%s'\n", toreplace); */
 
-		// TODO: Need to compare to the actual end of the string or a var "cat" would also match for "cats_ass"
 		char* startofkey = matched_copy;
 		if(is_condition_pre) {
 			startofkey += strlen(data_cond_open_prefix);
@@ -317,7 +320,8 @@ char* my_render_template(const char* template_data, unsigned long len, const cha
 			strcpy(key, keys[i]);
 			/* printf("key: '%s'\n", key); */
 
-			int cmp_res = strncmp(startofkey, key, keylen);
+			char* token = strtok(startofkey, close_and_data_cond_separator);
+			int cmp_res = strcmp(token, key);
 			if(cmp_res == 0) {
 				/* printf("FOUND\n"); */
 				char* replaced;

--- a/src/template_functions.c
+++ b/src/template_functions.c
@@ -201,21 +201,46 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 	const char* open = options.placeholder_open;
 	const char* close = options.placeholder_close;
 	const char* data_open = options.data_open;
+	const char* data_cond_separator = options.data_cond_separator;
+	const char* data_cond_open_prefix = options.data_cond_open_prefix;
+	const char* data_cond_close_prefix = options.data_cond_close_prefix;
 
+	// Setup defaults
 	if(open == NULL) open = "{{";
 	if(close == NULL) close = "}}";
 	if(data_open == NULL) data_open = "";
+	if(data_cond_separator == NULL) data_cond_separator = " ";
+	if(data_cond_open_prefix == NULL) data_cond_open_prefix = "#";
+	if(data_cond_close_prefix == NULL) data_cond_close_prefix = "/";
 
 	int template_length = strlen(template_data) + 1;
 	char* output = malloc(template_length);
 	strcpy(output, template_data);
 
-	int start = -1, length = -1;
+	int start = 0, length = 0;
 	while(get_surrounded_with(output, open, close, &start, &length)) {
+		// Get the match, inside the open and close braces
 		char matched[length+1];
 		memset(matched, 0, length + 1);
 		strncpy(matched, output + start, length);
 
+		// TODO: Do some logic here to check if its a condition
+		// If we have the separator
+		char* data_separated = strstr(matched, data_cond_separator);
+		if(data_separated != NULL) {
+			printf("Data '%s' has condition separator, value = '%s'\n", matched, data_separated+strlen(data_cond_separator));
+		}
+
+		// If we start with a condition
+		if(strstr(matched, data_cond_open_prefix) == matched) {
+			printf("Data '%s' has condition prefix\n", matched);
+
+			// 1) Get the closing element {{/data}}
+			// 2) Replace any placeholders in between the match
+			// 3) Replace the entire match after #2 with the appropriate data value
+		}
+
+		// Reassemble the entire placeholder and replace it
 		char toreplace[strlen(open) + strlen(matched) + strlen(close) + 1];
 		strcpy(toreplace, open);
 		strcat(toreplace, matched);

--- a/src/template_functions.c
+++ b/src/template_functions.c
@@ -224,20 +224,27 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 		memset(matched, 0, length + 1);
 		strncpy(matched, output + start, length);
 
+		int is_condition = 0;
+
 		// TODO: Do some logic here to check if its a condition
 		// If we have the separator
 		char* data_separated = strstr(matched, data_cond_separator);
 		if(data_separated != NULL) {
-			printf("Data '%s' has condition separator, value = '%s'\n", matched, data_separated+strlen(data_cond_separator));
+			is_condition = 1;
+			data_separated += strlen(data_cond_separator);
+			printf("Data '%s' has condition separator, value = '%s'\n", matched, data_separated);
 		}
 
 		// If we start with a condition
+		char* data_inside = NULL;
 		if(strstr(matched, data_cond_open_prefix) == matched) {
+			is_condition = 1;
 			printf("Data '%s' has condition prefix\n", matched);
 
 			// 1) Get the closing element {{/data}}
 			// 2) Replace any placeholders in between the match
-			// 3) Replace the entire match after #2 with the appropriate data value
+			// 3) Set the data_inside to the replace inner text
+			data_inside = "test";
 		}
 
 		// Reassemble the entire placeholder and replace it
@@ -246,6 +253,7 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 		strcat(toreplace, matched);
 		strcat(toreplace, close);
 
+		// Get the token value from the input data
 		unsigned int i = 0;
 		for(; i < len; ++i) {
 			unsigned int keylen = strlen(data_open) + strlen(keys[i]);
@@ -254,6 +262,7 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			strcat(key, keys[i]);
 
 			if(strncmp(matched, key, keylen) == 0) {
+				// TODO: Store the match and do the replacement later (if not a condition)
 				char* replaced = str_replace(output, toreplace, values[i]);
 				free(output);
 				output = replaced;
@@ -261,10 +270,14 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			}
 		}
 
+		// If the key wasn't found
 		if(i >= len) {
 			char* replaced = str_replace(output, toreplace, "");
 			free(output);
 			output = replaced;
+		} else {
+			// Do stuff if it is a condition
+			// Else, do the normal replacement (from the TODO above)
 		}
 	}
 

--- a/src/template_functions.c
+++ b/src/template_functions.c
@@ -265,33 +265,30 @@ char* my_render_template(const char* template_data, unsigned long len, const cha
 
 			char* closing_instance = strstr(matched_start, closing_text);
 			// TODO: Add support for placeholder with no end
-			/* if(closing_instance == NULL) { */
-			/* 	closing_instance = matched_start + strlen(matched_copy); */
-			/* } */
+			if(closing_instance != NULL) {
+				// 2) Get the data the placeholders
+				char* data_inside_start = matched_start + strlen(matched_copy) + strlen(open);
+				unsigned long data_inside_len = (unsigned long)closing_instance - (unsigned long)data_inside_start;
+				char data_inside[data_inside_len + 1];
+				memset(data_inside, 0, data_inside_len + 1);
+				strncpy(data_inside, data_inside_start, data_inside_len);
 
-			/* printf("Closing element %s found at (%u) %s.\n", closing_text, (unsigned long)closing_instance, closing_instance); */
+				// 3) Set the data to the replace inner text
+				// Append to the existing data
+				unsigned long new_data_len = data_inside_len;
+				if(data) new_data_len += strlen(data);
 
-			// 2) Get the data the placeholders
-			char* data_inside_start = matched_start + strlen(matched_copy) + strlen(open);
-			unsigned long data_inside_len = (unsigned long)closing_instance - (unsigned long)data_inside_start;
-			char data_inside[data_inside_len + 1];
-			memset(data_inside, 0, data_inside_len + 1);
-			strncpy(data_inside, data_inside_start, data_inside_len);
+				char* new_data = malloc(new_data_len + 1);
+				memset(new_data, 0, new_data_len + 1);
+				if(data) strcpy(new_data, data);
+				strcat(new_data, data_inside);
+				if(data) free(data);
+				data = new_data;
 
-			// 3) Set the data to the replace inner text
-			// Append to the existing data
-			unsigned long new_data_len = data_inside_len;
-			if(data) new_data_len += strlen(data);
+				// 4) Set match_len so we have the whole match
+				match_len = ((unsigned long)closing_instance + closing_len) - (unsigned long)matched_start - strlen(open) - strlen(close);
 
-			char* new_data = malloc(new_data_len + 1);
-			memset(new_data, 0, new_data_len + 1);
-			if(data) strcpy(new_data, data);
-			strcat(new_data, data_inside);
-			if(data) free(data);
-			data = new_data;
-
-			// 4) Reset match_len so we actually have the whole match
-			match_len = ((unsigned long)closing_instance + closing_len) - (unsigned long)matched_start - strlen(open) - strlen(close);
+			}
 		}
 
 		/* if(data) printf("Data: '%s'\n", data); */
@@ -326,12 +323,12 @@ char* my_render_template(const char* template_data, unsigned long len, const cha
 				char* replaced;
 				if(data) {
 					/* printf("HAVE DATA\n"); */
-					if(values[i]) {
+					if(values[i] && strlen(values[i])) {
 						/* printf("TRUE VALUE\n"); */
 						replaced = str_replace(output, toreplace, data);
 					} else {
 						/* printf("FALSE VALUE\n"); */
-						continue;
+						replaced = str_replace(output, toreplace, "");
 					}
 				} else {
 					/* printf("SUB VALUE\n"); */

--- a/src/template_functions.c
+++ b/src/template_functions.c
@@ -84,9 +84,9 @@ STATIC char* str_replace(char* orig, const char* rep, const char* with) {
 	char* result;  // the return string
 	char* ins;     // the next insert point
 	char* tmp;     // varies
-	int len_rep;   // length of rep (the string to remove)
-	int len_with;  // length of with (the string to replace rep with)
-	int count;     // number of replacements
+	unsigned long len_rep;   // length of rep (the string to remove)
+	unsigned long len_with;  // length of with (the string to replace rep with)
+	unsigned long count;     // number of replacements
 
 	// sanity checks and initialization
 	if(!orig || !rep) return NULL;
@@ -113,7 +113,7 @@ STATIC char* str_replace(char* orig, const char* rep, const char* with) {
 	//    orig points to the remainder of orig after "end of rep"
 	while(count--) {
 			ins = strstr(orig, rep);
-			int len_front = ins - orig;
+			unsigned long len_front = ins - orig;
 			tmp = strncpy(tmp, orig, len_front) + len_front;
 			tmp = strcpy(tmp, with) + len_with;
 			orig += len_front + len_rep; // move to next "end of rep"
@@ -124,7 +124,7 @@ STATIC char* str_replace(char* orig, const char* rep, const char* with) {
 }
 
 STATIC const char* get_last_token(const char* current, unsigned int token_count, const char* tokens[]) {
-	unsigned int remaining_len = strlen(current);
+	unsigned long remaining_len = strlen(current);
 	const char* next_token = &current[remaining_len];
 	const char* last_delimiter = NULL;
 
@@ -143,7 +143,7 @@ STATIC const char* get_last_token(const char* current, unsigned int token_count,
 }
 
 STATIC const char* my_strtok(const char* current, unsigned int token_count, const char* tokens[]) {
-	unsigned int remaining_len = strlen(current);
+	unsigned long remaining_len = strlen(current);
 	const char* next_token = &current[remaining_len];
 
 	unsigned int i = 0;
@@ -162,7 +162,7 @@ STATIC const char* my_strtok(const char* current, unsigned int token_count, cons
 	return NULL;
 }
 
-STATIC int get_surrounded_with(const char* template, const char* open, const char* close, int* start, int* length) {
+STATIC unsigned int get_surrounded_with(const char* template, const char* open, const char* close, long* start, long* length) {
 	*start = -1;
 	*length = -1;
 
@@ -188,10 +188,10 @@ STATIC int get_surrounded_with(const char* template, const char* open, const cha
 	return 0;
 }
 
-char* my_render_template(const char* template_data, int len, const char* data[], struct RenderOptions options) {
+char* my_render_template(const char* template_data, unsigned long len, const char* data[], struct RenderOptions options) {
 	const char* keys[len];
 	const char* values[len];
-	unsigned int i;
+	unsigned long i;
 	for(i = 0; i < len; i++) {
 		keys[i] = (char *)data[i*2];
 		values[i] = (char *)data[i*2+1];
@@ -211,11 +211,12 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 	if(data_cond_open_prefix == NULL) data_cond_open_prefix = "#";
 	if(data_cond_close_prefix == NULL) data_cond_close_prefix = "/";
 
-	int template_length = strlen(template_data) + 1;
+	// Create a copy of the template to work with
+	unsigned long template_length = strlen(template_data) + 1;
 	char* output = malloc(template_length);
 	strcpy(output, template_data);
 
-	int start = 0, match_len = 0;
+	long start = 0, match_len = 0;
 	while(get_surrounded_with(output, open, close, &start, &match_len)) {
 		char* matched_start = output + start;
 
@@ -224,15 +225,14 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 		memset(matched_copy, 0, match_len + 1);
 		strncpy(matched_copy, matched_start, match_len);
 
-		int is_condition_sep = 0;
+		/* int is_condition_sep = 0; */
 		int is_condition_pre = 0;
 		char* data = NULL;
 
-		// TODO: Do some logic here to check if its a condition
 		// If we have the separator
 		char* data_separated = strstr(matched_copy, data_cond_separator);
 		if(data_separated != NULL) {
-			is_condition_sep = 1;
+			/* is_condition_sep = 1; */
 			data_separated += strlen(data_cond_separator);
 
 			// Copy the separated data to the data
@@ -250,7 +250,7 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			/* printf("Element '%s' has condition prefix at (%u)\n", matched_copy, (unsigned)matched_start); */
 
 			// 1) Get the closing element {{/data}}
-			int closing_len =
+			unsigned long closing_len =
 				strlen(open) +
 				strlen(data_cond_close_prefix) +
 				strlen(matched_copy) + strlen(data_cond_open_prefix) +
@@ -269,18 +269,18 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			/* 	closing_instance = matched_start + strlen(matched_copy); */
 			/* } */
 
-			/* printf("Closing element %s found at (%u) %s.\n", closing_text, (unsigned)closing_instance, closing_instance); */
+			/* printf("Closing element %s found at (%u) %s.\n", closing_text, (unsigned long)closing_instance, closing_instance); */
 
 			// 2) Get the data the placeholders
 			char* data_inside_start = matched_start + strlen(matched_copy) + strlen(open);
-			int data_inside_len = (unsigned)closing_instance - (unsigned)data_inside_start;
+			unsigned long data_inside_len = (unsigned long)closing_instance - (unsigned long)data_inside_start;
 			char data_inside[data_inside_len + 1];
 			memset(data_inside, 0, data_inside_len + 1);
 			strncpy(data_inside, data_inside_start, data_inside_len);
 
 			// 3) Set the data to the replace inner text
 			// Append to the existing data
-			int new_data_len = data_inside_len;
+			unsigned long new_data_len = data_inside_len;
 			if(data) new_data_len += strlen(data);
 
 			char* new_data = malloc(new_data_len + 1);
@@ -291,7 +291,7 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			data = new_data;
 
 			// 4) Reset match_len so we actually have the whole match
-			match_len = ((unsigned)closing_instance + closing_len) - (unsigned)matched_start - strlen(open) - strlen(close);
+			match_len = ((unsigned long)closing_instance + closing_len) - (unsigned long)matched_start - strlen(open) - strlen(close);
 		}
 
 		/* if(data) printf("Data: '%s'\n", data); */
@@ -323,8 +323,6 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			int cmp_res = strncmp(startofkey, key, keylen);
 			if(cmp_res == 0) {
 				/* printf("FOUND\n"); */
-
-				// TODO: Store the match and do the replacement later (if not a condition)
 				char* replaced;
 				if(data) {
 					/* printf("HAVE DATA\n"); */
@@ -353,20 +351,17 @@ char* my_render_template(const char* template_data, int len, const char* data[],
 			char* replaced = str_replace(output, toreplace, "");
 			free(output);
 			output = replaced;
-		} else {
-			// Do stuff if it is a condition
-			// Else, do the normal replacement (from the TODO above)
 		}
 	}
 
 	return output;
 }
 
-char* render_template(const char* template_data, int len, const char* data[]) {
+char* render_template(const char* template_data, unsigned long len, const char* data[]) {
 	return my_render_template(template_data, len, data, (struct RenderOptions){});
 }
 
-char* my_render_template_file(const char* filename, int len, const char* data[], struct RenderOptions options) {
+char* my_render_template_file(const char* filename, unsigned long len, const char* data[], struct RenderOptions options) {
 	char* contents = read_file_contents(filename);
 	if(!contents) return NULL;
 
@@ -376,6 +371,6 @@ char* my_render_template_file(const char* filename, int len, const char* data[],
 	return rendered;
 }
 
-char* render_template_file(const char* filename, int len, const char* data[]) {
+char* render_template_file(const char* filename, unsigned long len, const char* data[]) {
 	return my_render_template_file(filename, len, data, (struct RenderOptions){});
 }

--- a/src/template_functions.h
+++ b/src/template_functions.h
@@ -33,7 +33,6 @@
 struct RenderOptions {
 	const char* placeholder_open;       // "{{"
 	const char* placeholder_close;      // "}}"
-	const char* data_open;              // "data."
 	const char* data_cond_separator;    // " " If a separator is defined than we assume the structure {{cond data}}
 	const char* data_cond_open_prefix;  // "#" If a prefix is defined than we assume this is {{#cond}} data {{/cond}} (mustache style)
 	const char* data_cond_close_prefix; // "/"

--- a/src/template_functions.h
+++ b/src/template_functions.h
@@ -47,8 +47,8 @@ struct RenderOptions {
  * options: RenderOptions structure with values for rendering templates
  * returns: rendered template, null terminated
  */
-char* my_render_template (const char* template_data, int len, const char* data[], struct RenderOptions options);
-char* render_template (const char* template_data, int len, const char* data[]);
+char* my_render_template (const char* template_data, unsigned long len, const char* data[], struct RenderOptions options);
+char* render_template (const char* template_data, unsigned long len, const char* data[]);
 
 /**
  * Render a template with arrays of key/value pairs from a file
@@ -59,7 +59,7 @@ char* render_template (const char* template_data, int len, const char* data[]);
  * options: RenderOptions structure with values for rendering templates
  * returns: rendered template, null terminated
  */
-char* my_render_template_file (const char* filename, int len, const char* data[], struct RenderOptions options);
-char* render_template_file (const char* filename, int len, const char* data[]);
+char* my_render_template_file (const char* filename, unsigned long len, const char* data[], struct RenderOptions options);
+char* render_template_file (const char* filename, unsigned long len, const char* data[]);
 
 #endif

--- a/src/template_functions.h
+++ b/src/template_functions.h
@@ -31,13 +31,12 @@
 #include <ctype.h>
 
 struct RenderOptions {
-	const char* placeholder_open;    // == "{{"
-	const char* placeholder_close;   // == "}}"
-	const char* data_open;
-
-	/* const char* condition_delimeter; // == " " */
-	/* const char* section_open;        // == "#" */
-	/* const char* section_end;         // == "/" */
+	const char* placeholder_open;       // "{{"
+	const char* placeholder_close;      // "}}"
+	const char* data_open;              // "data."
+	const char* data_cond_separator;    // " " If a separator is defined than we assume the structure {{cond data}}
+	const char* data_cond_open_prefix;  // "#" If a prefix is defined than we assume this is {{#cond}} data {{/cond}} (mustache style)
+	const char* data_cond_close_prefix; // "/"
 } options;
 
 /**


### PR DESCRIPTION
Related Issue (required): #22 #23

Status (required): wip

Comments: Still have a couple `TODO` items left to finish off. Still have to update the readme with this use case. 

Summary of changes: Old tests all remaining passing. Added support for custom condition opening prefix. The default is `#` and you use a closing brace with a customizable but default to `/`. The effect of these defaults is able to render from mustache style documents! For example:

``` html
<html>
   <head>
      <title>Homepage</title>
   </head>
   <body>
       Hello world! I am {{#is_extra_happy}}so  {{/is_extra_happy}}good, thank you for asking!!
   </body>
<html>
```

There is also a customizable closing delimiter so you could do `{{is_extra_happy so }}` instead. The space after `is_extra_happy` is the default "after" delimiter to put the true data but I'll leave that for the readme...